### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/functions/_vish_command_end.fish
+++ b/functions/_vish_command_end.fish
@@ -3,7 +3,7 @@ function _vish_command_end --on-event fish_postexec
 		return
 	end
 	for icmd in $VISH_INTERACTIVE_CMDS
-		if echo $argv[1] | grep $icmd > /dev/null ^ /dev/null
+		if echo $argv[1] | grep $icmd > /dev/null 2> /dev/null
 			return
 		end
 	end


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
